### PR TITLE
feat(safari): configure gitpod url

### DIFF
--- a/src/Shared (Extension)/Resources/manifest.json
+++ b/src/Shared (Extension)/Resources/manifest.json
@@ -32,7 +32,7 @@
     }],
 
     "browser_action": {
-        "default_popup": "popup.html",
+        "default_popup": "options.html",
         "default_icon": {
             "16": "images/toolbar-icon-16.png",
             "19": "images/toolbar-icon-19.png",


### PR DESCRIPTION
## Description

Enables the extension options using HTML configuration. It would be nice to move this configuration to iOS -> Settings -> Safari -> Extensions at a later date.

## Related Issue(s)

Fixes https://github.com/gitpod-io/gitpod-mobile-ios/issues/41

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->


<a href="https://gitpod.io/#https://github.com/gitpod-io/gitpod-mobile-ios/pull/61"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

