### PR TITLE
Fix "Extensions on iPadOS must have a non-persistent background page"

### DIFF
--- a/src/Shared (Extension)/Resources/manifest.json
+++ b/src/Shared (Extension)/Resources/manifest.json
@@ -15,7 +15,8 @@
     },
 
     "background": {
-        "scripts": [ "bundles/background.bundle.js" ]
+        "scripts": [ "bundles/background.bundle.js" ],
+        "persistent": false
     },
 
     "content_scripts": [{


### PR DESCRIPTION
## Description
I encountered the below error while building on iPadOS 15.4 Beta 4

[Related Apple Docs](https://developer.apple.com/documentation/safariservices/safari_web_extensions/optimizing_your_web_extension_for_safari)

![IMG_0021](https://user-images.githubusercontent.com/13267947/157360553-cd00699f-38f4-4dc5-ada7-c0c5416394b2.png)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A

## How to test
<!-- Provide steps to test this PR -->
Build and deploy to an iPad. Otherwise the extension works like a charm :)

## Release Notes

<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->


<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/gitpod-mobile-ios/pull/67"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>

